### PR TITLE
docs(README): 更新模型调用版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
 分支v1 默认初版模型调用
-分支v2 升级为最新版模型调用
+分支v2 升级为最新版模型调用.
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
 分支v1 默认初版模型调用
+分支v2 升级为最新版模型调用
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:


### PR DESCRIPTION
- 在 README.md 中提到分支 v2 已升级为最新版模型调用
- 保留了原有的 v1 分支信息